### PR TITLE
Fix register error 02

### DIFF
--- a/clipperbot/video/download.py
+++ b/clipperbot/video/download.py
@@ -238,7 +238,8 @@ async def sanitize_chnurl(chn_url:str):
         chn_url = chn_url.split("?")[0].split("#")[0]  # remove url parameters
     if chn_url.startswith("https://www.youtube.com/c/"):  # custom url
         # channel url in the form of /channel/
-        chn_url = (await _fetch_yt_chn_data(chn_url))["channel_url"]
+        chn_id = (await _fetch_yt_chn_data(chn_url))["id"]
+        chn_url = "https://www.youtube.com/channel/" + chn_id
     
     if not chn_url.startswith("https://www.youtube.com/channel/"):
         raise ValueError("Only Youtube channels are implemented.")


### PR DESCRIPTION
Fixes #21 .

The problem was that "channel_url" was no longer in the metadata returned by youtube-dl.