### PR TITLE
Wait for single stream

### DIFF
--- a/clipperbot/bot/__init__.py
+++ b/clipperbot/bot/__init__.py
@@ -43,7 +43,7 @@ class ClipBot(commands.Bot):
 
         # {text_chn : channel_url}
         self.channel_mapping = PersistentDict(database, "channels", int, str)
-        self.listens = {}  # {text_chn : listen_tasks}
+        self.listens:dict[discord.TextChannel, asyncio.Task] = {}
         self.ready = False
 
         self.check(lambda ctx: self.ready)

--- a/clipperbot/bot/admin.py
+++ b/clipperbot/bot/admin.py
@@ -212,11 +212,9 @@ False by default. Valid arguments: `true`, `false`"
 
             del self.bot.listens[txtchn]
 
-        try:
-            del self.bot.channel_mapping[txtchn.id]
-        except KeyError:
-            pass
         chn_url = self.bot.channel_mapping[txtchn.id]
+        del self.bot.channel_mapping[txtchn.id]
+
         return chn_url
     
     # @commands.command

--- a/clipperbot/video/download.py
+++ b/clipperbot/video/download.py
@@ -258,7 +258,7 @@ async def wait_for_stream(channel_url:str, poll_interval=POLL_INTERVAL):
             logger.debug(f"{channel_url} cache expired or none.")
             while True:
                 logger.debug(f"Fetching for live stream of {channel_url}")
-                if "youtube.com/" in channel_url or "twitch.com/" in channel_url:
+                if "youtube.com/" in channel_url or "twitch.tv/" in channel_url:
                     try:
                         metadata_dict = await _fetch_yt_chn_stream(channel_url)
                     except RateLimited:
@@ -266,7 +266,7 @@ async def wait_for_stream(channel_url:str, poll_interval=POLL_INTERVAL):
                         continue
                 else:
                     raise ValueError(f"{channel_url} url is"
-                        "not implemented.")
+                        " not implemented.")
 
                 if metadata_dict is not None:
                     

--- a/clipperbot/video/download.py
+++ b/clipperbot/video/download.py
@@ -255,7 +255,7 @@ async def wait_for_stream(channel_url:str, poll_interval=POLL_INTERVAL):
             logger.debug(f"{channel_url} cache expired or none.")
             while True:
                 logger.debug(f"Fetching for live stream of {channel_url}")
-                if "youtube.com/" in channel_url:
+                if "youtube.com/" in channel_url or "twitch.com/" in channel_url:
                     try:
                         metadata_dict = await _fetch_yt_chn_stream(channel_url)
                     except RateLimited:
@@ -352,6 +352,9 @@ def fetch_yt_metadata(url:str):
     ytdl_logger.addHandler(logging.NullHandler())  # f yt-dl logs
 
     # options referenced from https://github.com/sparanoid/live-dl/blob/3e76be969d94747aa5d9f83b34bc22e14e0929be/live-dl
+    #
+    # Problem with cookies in current implementation: 
+    # https://github.com/ytdl-org/youtube-dl/issues/22613
     ydl_opts = {
         "logger" : ytdl_logger,
         "noplaylist" : True,
@@ -359,9 +362,12 @@ def fetch_yt_metadata(url:str):
         "skip_download": True,
         "forcejson": True,
         "no_color": True,
-        "referer": 'https://www.youtube.com/feed/subscriptions',
         "cookiefile": "cookies.txt",
     }
+
+    if "youtube.com/" in url:
+        ydl_opts["referer"] = "https://www.youtube.com/feed/subscriptions"
+
     try:
         with ytdl.YoutubeDL(ydl_opts) as ydl:
             info_dict = ydl.extract_info(url, download=False)


### PR DESCRIPTION
The `stream` command can now be used for livestreams that are upcoming and not live yet.