### PR TITLE
Change edit to trim

### DIFF
--- a/clipperbot/bot/help_strings.py
+++ b/clipperbot/bot/help_strings.py
@@ -25,7 +25,6 @@ a        | clip audio only"""
 
 clip_command_description = \
 f"""Clip relative to the current time. Use `a` for audio only.
-If the clip file is too big, a direct download link is posted instead, if enabled for the server. The ddl is only temporary, so please don't link to it.
 Also check `help clip fromstart`
 Maximum duration is {int(MAX_DURATION.total_seconds()/60)} minutes.
 
@@ -33,7 +32,9 @@ Sample Usage:
 c        | clip the last {int(DEF_CLIP_DURATION.total_seconds())} seconds
 c 20 5   | clip from 20 seconds ago with a duration of 5 s
 c 3:40 - | clip the last 3 minutes and 40 seconds
-a        | clip audio only"""
+a        | clip audio only
+
+If the clip file is too big for discord, a direct download link is posted instead, if enabled for the server. The ddl is only temporary, so please don't link to it."""
 
 
 fromstart_subcommand_description = \
@@ -41,18 +42,6 @@ f"""Clip with timestamp relative to the start of the stream.
 
 Sample Usage:
 c fromstart 1:30:00 90  | clip from 1:30:00 to 1:31:30"""
-
-
-adjust_command_description = \
-f"""Instead of using this command, you can edit the original command directly!
-
-Reply to a clip to post it again with modified start point and duration.
-Also consider deleting the original clip if you don't need it.
-
-Sample Usage:
-adjust +5    | shift the clip 5 seconds forward
-adjust 0  +3 | increase the duration by 3 seconds
-adjust +5 -5 | shift the clip 5 seconds forward, then reduce duration by 5 seconds, effectively trimming 5 seconds from the beginning."""
 
 
 channel_permission_description = \
@@ -65,9 +54,7 @@ Example: to disallow video clips but allow audio clips in a text channel, run th
 #stream-clips: channel_permission add Clipping
 (The commands under the Clipping category can only be used in #stream-clips)
 #stream-noises: channel_permission add a
-(The `a` command can be used in #stream-noises)
-#stream-noises: channel_permission add adjust
-(The `adjust` command can be used in #stream-noises)"""
+(The `a` command can be used in #stream-noises)"""
 
 
 role_permission_description = \

--- a/clipperbot/bot/user.py
+++ b/clipperbot/bot/user.py
@@ -80,13 +80,7 @@ class Clipping(commands.Cog):
                 ctx, relative_start, duration
             )
         except ValueError:
-            if relative_start == "adj" or relative_start == "adjust":
-                await ctx.send(
-                    f"Wrong usage, try `{ctx.prefix}adjust` while replying to a clip?"
-                )
-                return
-            else:
-                raise commands.BadArgument()
+            raise commands.BadArgument()
 
         audio_only = ctx.invoked_with in ["audio", "a"]
 
@@ -185,46 +179,6 @@ class Clipping(commands.Cog):
             from_start -= stream.start_time - stream.actual_start
 
         await self._create_n_send_clip(ctx, from_start, duration, audio_only)
-
-    adjust_brief = "Reply to a clip to adjust it."
-    @commands.command(
-        aliases=["adj"],
-        help=help_strings.adjust_command_description,
-        brief=adjust_brief,
-    )
-    async def adjust(
-        self,
-        ctx,
-        start_adjust,
-        duration_adjust: str = "0",
-    ):
-        try:
-            start_adjust = to_timedelta(start_adjust)
-        except Exception as e:
-            raise commands.UserInputError from e
-
-        if ctx.message.reference is None:
-            await ctx.reply("You need to reply to the clip to adjust.")
-            return
-        try:
-            idx = self.sent_clips.index(ctx.message.reference)
-            og_clip = self.sent_clips[idx]
-        except (ValueError, KeyError):
-            self.bot.logger.info("Requested adjust on clip message that is"
-                                 " no longer tracked.")
-            return
-
-        from_time = og_clip.from_time + start_adjust
-        duration = og_clip.duration + to_timedelta(duration_adjust)
-        relative_start = None
-
-        await self._create_n_send_clip(
-            ctx,
-            from_time,
-            duration,
-            audio_only=og_clip.audio_only,
-            relative_start=relative_start,
-        )
 
     @commands.Cog.listener()
     async def on_message_edit(self, before: discord.Message, after: discord.Message):


### PR DESCRIPTION
Editing a clip command message can be used to "trim" it. This removes the direct adjust by editing behavior, also the `adjust` command.

Editing `c 20 15` to `c 20 15 trim -2 +3` trims 5 second from the beginning and adds 3 seconds to the end.